### PR TITLE
add mpe support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,8 @@
                  [cli-matic "0.4.3"]
                  [clj-http "3.12.3"]
                  [hbs "1.0.3"]
+                 [http-kit "2.5.3"]
+                 [compojure "1.6.2"]
                  [org.slf4j/slf4j-nop "1.7.36"]]
   :source-paths ["src/main/clojure"]
   :java-source-paths ["src/main/java" "vendors/mmj2/src" "vendors/JSON-java/"]

--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,7 @@
                  [http-kit "2.5.3"]
                  [compojure "1.6.2"]
                  [ring/ring-core "1.9.5"]
+                 [org.clojure/tools.logging "1.2.4"]
                  [org.slf4j/slf4j-nop "1.7.36"]]
   :source-paths ["src/main/clojure"]
   :java-source-paths ["src/main/java" "vendors/mmj2/src" "vendors/JSON-java/"]

--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
                  [hbs "1.0.3"]
                  [http-kit "2.5.3"]
                  [compojure "1.6.2"]
+                 [ring/ring-core "1.9.5"]
                  [org.slf4j/slf4j-nop "1.7.36"]]
   :source-paths ["src/main/clojure"]
   :java-source-paths ["src/main/java" "vendors/mmj2/src" "vendors/JSON-java/"]

--- a/src/main/clojure/mmtk/cmd/mpe.clj
+++ b/src/main/clojure/mmtk/cmd/mpe.clj
@@ -4,6 +4,8 @@
              [java.nio.file FileSystems]
              [java.net URI])
     (:require [clojure.java.io :as io]
+              [clojure.java.browse :refer [browse-url]]
+              [clj-http.client :as client]
               [mmtk.cmd.init :as init])
     (:use [compojure.route :only [files not-found]]
           [compojure.core :only [defroutes GET]]
@@ -11,6 +13,7 @@
           org.httpkit.server))
 
 (def countdown (CountDownLatch. 1))
+(def delayed-countdown (delay (.countDown countdown) 3000))
 
 (defn start-mpe
     "start a web server for mpe"
@@ -28,10 +31,25 @@
           fsys (FileSystems/newFileSystem uri {})]
         ;static http server
         (defroutes all-routes
+                   (GET "/terminate" [] @delayed-countdown {:status  200
+                                                            :body    "done!"})
                    (GET "/mpeuni/:file" [file]
-                     {:status  200
-                      :body    (Files/newInputStream (.getPath fsys "mpeuni" (into-array String [file])) (into-array OpenOption [StandardOpenOption/READ]))})
+                       {:status  200
+                        :body    (Files/newInputStream (.getPath fsys "mpeuni" (into-array String [file])) (into-array OpenOption [StandardOpenOption/READ]))})
                    (not-found "<p>Page not found.</p>"))
         (run-server (wrap-content-type all-routes) {:port 7979}))
     (println "... mpe server started on 7979!")
+    (browse-url "http://localhost:7979/mpeuni/mmset.html")
     (.await countdown))
+
+(defn stop-mpe
+    "start a web server for mpe"
+    [& args]
+    (try
+        (client/get "http://localhost:7979/terminate")
+        (catch Exception e 0)))
+
+(defn update-mpe
+    "update mpeuni.zip from metamath site"
+    [& args]
+    (init/url-handler "http://us.metamath.org/downloads/mpeuni.zip"))

--- a/src/main/clojure/mmtk/cmd/mpe.clj
+++ b/src/main/clojure/mmtk/cmd/mpe.clj
@@ -1,10 +1,13 @@
 (ns mmtk.cmd.mpe
     (:import [java.util.concurrent CountDownLatch]
+             [java.nio.file Files OpenOption StandardOpenOption]
              [java.nio.file FileSystems]
              [java.net URI])
-    (:require [ mmtk.cmd.init :as init])
+    (:require [clojure.java.io :as io]
+              [mmtk.cmd.init :as init])
     (:use [compojure.route :only [files not-found]]
-          [compojure.core :only [defroutes]]
+          [compojure.core :only [defroutes GET]]
+          [ring.middleware.content-type :only [wrap-content-type]]
           org.httpkit.server))
 
 (def countdown (CountDownLatch. 1))
@@ -14,15 +17,21 @@
     [& args]
 
     ;prepare zipped archival
-    (init/url-handler "http://us.metamath.org/downloads/mpeuni.zip")
-    (println "data downlaoded!")
+    (if (not (.exists (io/file "database" "mpeuni.zip")))
+        (do (init/url-handler "http://us.metamath.org/downloads/mpeuni.zip")
+            (println "... mpeuni.zip downlaoded!"))
+        (println "... mpeuni.zip already downlaoded!"))
+
+    (println "... ready for serve mpe server on 7979!")
     (let [cur (System/getProperty "user.dir")
-          uri (format "jar:file:%s/database/mpeuni.zip" (.toString cur))
-          fsys (FileSystems/newFileSystem uri {})
-          root (.getPath fsys "/" (into-array String []))]
+          uri (URI. (format "jar:file:%s/database/mpeuni.zip" (.toString cur)))
+          fsys (FileSystems/newFileSystem uri {})]
         ;static http server
         (defroutes all-routes
-                   (files "/" {:root (.toString root)}) ; static file url prefix /static, in `public` folder
-                   (not-found "<p>Page not found.</p>")) ; all other, return 404
-        (run-server all-routes {:port 8080}))
+                   (GET "/mpeuni/:file" [file]
+                     {:status  200
+                      :body    (Files/newInputStream (.getPath fsys "mpeuni" (into-array String [file])) (into-array OpenOption [StandardOpenOption/READ]))})
+                   (not-found "<p>Page not found.</p>"))
+        (run-server (wrap-content-type all-routes) {:port 7979}))
+    (println "... mpe server started on 7979!")
     (.await countdown))

--- a/src/main/clojure/mmtk/cmd/mpe.clj
+++ b/src/main/clojure/mmtk/cmd/mpe.clj
@@ -1,0 +1,28 @@
+(ns mmtk.cmd.mpe
+    (:import [java.util.concurrent CountDownLatch]
+             [java.nio.file FileSystems]
+             [java.net URI])
+    (:require [ mmtk.cmd.init :as init])
+    (:use [compojure.route :only [files not-found]]
+          [compojure.core :only [defroutes]]
+          org.httpkit.server))
+
+(def countdown (CountDownLatch. 1))
+
+(defn start-mpe
+    "start a web server for mpe"
+    [& args]
+
+    ;prepare zipped archival
+    (init/url-handler "http://us.metamath.org/downloads/mpeuni.zip")
+    (println "data downlaoded!")
+    (let [cur (System/getProperty "user.dir")
+          uri (format "jar:file:%s/database/mpeuni.zip" (.toString cur))
+          fsys (FileSystems/newFileSystem uri {})
+          root (.getPath fsys "/" (into-array String []))]
+        ;static http server
+        (defroutes all-routes
+                   (files "/" {:root (.toString root)}) ; static file url prefix /static, in `public` folder
+                   (not-found "<p>Page not found.</p>")) ; all other, return 404
+        (run-server all-routes {:port 8080}))
+    (.await countdown))

--- a/src/main/clojure/mmtk/cmd/pa.clj
+++ b/src/main/clojure/mmtk/cmd/pa.clj
@@ -1,24 +1,36 @@
 (ns mmtk.cmd.pa
     (:import [javax.swing JFrame]
-             [java.awt.event WindowListener]
-             [java.util.concurrent CountDownLatch]
-             [mmj.util BatchMMJ2]))
-
-(def countdown (CountDownLatch. 1))
+             [java.awt.event ComponentListener WindowListener]
+             [mmj.util BatchMMJ2])
+    (:require [mmtk.util.setting :as setting]
+              [mmtk.util.system :as system]))
 
 (defn invoke-pa [& args]
     (.runIt (BatchMMJ2.) (into-array String ["params/default.txt"]))
     (let [frames (JFrame/getFrames)
           frmcnt (alength frames)]
         (if (> frmcnt 0)
-            (.addWindowListener (aget frames 0)
-                                (proxy [WindowListener] []
-                                    (windowOpened [e])
-                                    (windowClosing [e] (.countDown countdown))
-                                    (windowClosed [e] (.countDown countdown))
-                                    (windowIconified [e])
-                                    (windowDeiconified [e])
-                                    (windowActivated [e])
-                                    (windowDeactivated [e])))
-            (.countDown countdown)))
-    (.await countdown))
+            (let [frm (aget frames 0)
+                  width (setting/get-val [:pa :width])
+                  height (setting/get-val [:pa :height])]
+                (.setSize frm width height)
+                (.setLocationRelativeTo frm nil)
+                (.addComponentListener frm
+                    (proxy [ComponentListener] []
+                        (componentResized [e]
+                            (setting/update-val [:pa :width] (.getWidth frm))
+                            (setting/update-val [:pa :height] (.getHeight frm)))
+                        (componentMoved [e])
+                        (componentShown [e])
+                        (componentHidden [e])))
+                (.addWindowListener frm
+                    (proxy [WindowListener] []
+                        (windowOpened [e])
+                        (windowClosing [e])
+                        (windowClosed [e]
+                            (system/shutdown!))
+                        (windowIconified [e])
+                        (windowDeiconified [e])
+                        (windowActivated [e])
+                        (windowDeactivated [e]))))))
+    (system/wait))

--- a/src/main/clojure/mmtk/main.clj
+++ b/src/main/clojure/mmtk/main.clj
@@ -2,7 +2,8 @@
     (:require [cli-matic.core :refer [run-cmd]]
               [mmtk.cmd.init :refer [init-workspace]]
               [mmtk.cmd.pa :refer [invoke-pa]]
-              [mmtk.cmd.batch :refer [invoke-batch]])
+              [mmtk.cmd.batch :refer [invoke-batch]]
+              [mmtk.cmd.mpe :refer [start-mpe]])
     (:gen-class))
 
 (def CONFIGURATION
@@ -25,6 +26,10 @@
                     :description "invoke the proof assistant"
                     :examples    ["mmtk pa"]
                     :runs        invoke-pa}
+                   {:command     "mpe"
+                    :description "start a web server for mpe"
+                    :examples    ["mmtk mpeuni"]
+                    :runs        start-mpe}
                    {:command     "batch"
                     :description "batch execution on a params file"
                     :examples    ["mmtk batch params/default.txt"]

--- a/src/main/clojure/mmtk/main.clj
+++ b/src/main/clojure/mmtk/main.clj
@@ -3,7 +3,7 @@
               [mmtk.cmd.init :refer [init-workspace]]
               [mmtk.cmd.pa :refer [invoke-pa]]
               [mmtk.cmd.batch :refer [invoke-batch]]
-              [mmtk.cmd.mpe :refer [start-mpe]])
+              [mmtk.cmd.mpe :refer [start-mpe stop-mpe update-mpe]])
     (:gen-class))
 
 (def CONFIGURATION
@@ -27,9 +27,20 @@
                     :examples    ["mmtk pa"]
                     :runs        invoke-pa}
                    {:command     "mpe"
-                    :description "start a web server for mpe"
-                    :examples    ["mmtk mpeuni"]
-                    :runs        start-mpe}
+                    :description "mpe related commands"
+                    :subcommands [{:command     "start"
+                                   :description "start mpe web server"
+                                   :examples    ["mmtk mpe start"]
+                                   :runs        start-mpe}
+                                  {:command     "stop"
+                                   :description "stop mpe web server"
+                                   :examples    ["mmtk mpe stop"]
+                                   :runs        stop-mpe}
+                                  {:command     "update"
+                                   :description "update mpeuni.zip from metamath site"
+                                   :examples    ["mmtk mpe update"]
+                                   :runs        update-mpe}
+                                  ]}
                    {:command     "batch"
                     :description "batch execution on a params file"
                     :examples    ["mmtk batch params/default.txt"]

--- a/src/main/clojure/mmtk/util/coll.clj
+++ b/src/main/clojure/mmtk/util/coll.clj
@@ -1,0 +1,10 @@
+(ns mmtk.util.coll)
+
+;; latest comment under above gist provides another
+;; simpler and more consistent version of deep-merge
+;; Source: https://gist.github.com/danielpcox/c70a8aa2c36766200a95#gistcomment-2759497
+(defn deep-merge [a & maps]
+    (if (map? a)
+        (apply merge-with deep-merge a maps)
+        (apply merge-with deep-merge maps)))
+

--- a/src/main/clojure/mmtk/util/setting.clj
+++ b/src/main/clojure/mmtk/util/setting.clj
@@ -1,0 +1,23 @@
+(ns mmtk.util.setting
+    (:require [clojure.java.io :as io]
+              [clj-yaml.core :as yaml]
+              [mmtk.util.coll :as coll]))
+
+(def settings (atom (yaml/parse-string (slurp (io/as-file "mmtk.yaml")))))
+
+(defn refresh-all []
+    (swap! settings coll/deep-merge (yaml/parse-string (slurp (io/as-file "mmtk.yaml")))))
+
+(defn get-val [keys]
+    (get-in @settings keys))
+
+(defn update-val [keys val]
+    (swap! settings update-in keys (constantly val)))
+
+(defn save-all []
+    (spit (io/as-file "mmtk.yaml") (yaml/generate-string @settings)))
+
+(.addShutdownHook (Runtime/getRuntime) (Thread. save-all))
+
+
+

--- a/src/main/clojure/mmtk/util/system.clj
+++ b/src/main/clojure/mmtk/util/system.clj
@@ -1,0 +1,12 @@
+(ns mmtk.util.system
+    (:import [java.util.concurrent CountDownLatch]))
+
+(def countdown (CountDownLatch. 1))
+
+(defn wait []
+    (.await countdown))
+
+(defn shutdown! []
+    (.countDown countdown))
+
+(def delayed-shutdown (delay (shutdown!) 3000))


### PR DESCRIPTION
Just set up a web server to serve mpeuni pages.

In order to reduce the storage cost, we use mpeuni.zip directly.